### PR TITLE
pref: remove redundant init_messages usage in llm.py

### DIFF
--- a/backend/apps/chat/task/llm.py
+++ b/backend/apps/chat/task/llm.py
@@ -148,8 +148,6 @@ class LLMService:
         else:
             self.chat_question.error_msg = ''
 
-        self.init_messages()
-
     @classmethod
     async def create(cls, *args, **kwargs):
         config: LLMConfig = await get_default_config()


### PR DESCRIPTION
fix #149