### PR TITLE
feat: improve Vite proxy to support LAN access 

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8000/api/v1
+VITE_API_BASE_URL=/api/v1
 VITE_APP_TITLE=SQLBot (Development)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,20 @@ export default defineConfig(({ mode }) => {
   console.info(mode)
   console.info(env)
   return {
+    server: {
+      host: '0.0.0.0',
+      open: true,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
+        '/xpack_static': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
+      },
+    },
     base: './',
     plugins: [
       vue(),


### PR DESCRIPTION
Modified vite.config.js to enable the frontend to access backend APIs over the local network.
Adjusted VITE_API_BASE_URL and added corresponding proxies for /api and /xpack_static.
Improved frontend-backend integration and multi-device debugging experience.