### PR TITLE
feat(embedding): support multi-turn conversation context for table RAG

### DIFF
--- a/backend/apps/datasource/crud/datasource.py
+++ b/backend/apps/datasource/crud/datasource.py
@@ -425,7 +425,7 @@ def get_table_obj_by_ds(session: SessionDep, current_user: CurrentUser, ds: Core
 
 
 def get_table_schema(session: SessionDep, current_user: CurrentUser, ds: CoreDatasource, question: str,
-                     embedding: bool = True) -> str:
+                     embedding: bool = True, history_questions: List[str] = None) -> str:
     schema_str = ""
     table_objs = get_table_obj_by_ds(session=session, current_user=current_user, ds=ds)
     if len(table_objs) == 0:
@@ -464,7 +464,7 @@ def get_table_schema(session: SessionDep, current_user: CurrentUser, ds: CoreDat
 
     # do table embedding
     if embedding and tables and settings.TABLE_EMBEDDING_ENABLED:
-        tables = calc_table_embedding(tables, question)
+        tables = calc_table_embedding(tables, question, history_questions)
     # splice schema
     if tables:
         for s in tables:

--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -115,6 +115,10 @@ class Settings(BaseSettings):
     TABLE_EMBEDDING_COUNT: int = 10
     DS_EMBEDDING_COUNT: int = 10
 
+    # Multi-turn embedding settings
+    MULTI_TURN_EMBEDDING_ENABLED: bool = True
+    MULTI_TURN_HISTORY_COUNT: int = 3
+
     ORACLE_CLIENT_PATH: str = '/opt/sqlbot/db_client/oracle_instant_client'
 
     @field_validator('SQL_DEBUG',
@@ -123,6 +127,7 @@ class Settings(BaseSettings):
                      'PARSE_REASONING_BLOCK_ENABLED',
                      'PG_POOL_PRE_PING',
                      'TABLE_EMBEDDING_ENABLED',
+                     'MULTI_TURN_EMBEDDING_ENABLED',
                      mode='before')
     @classmethod
     def lowercase_bool(cls, v: Any) -> Any:


### PR DESCRIPTION
## Summary
- 支持多轮对话上下文用于表 RAG 选择
- 在进行表嵌入匹配时，结合历史问题上下文提高表选择准确性
- 添加配置项控制多轮上下文功能开关和历史记录数量

## Changes
- `backend/apps/chat/curd/chat.py`: 添加获取历史问题的函数
- `backend/apps/chat/task/llm.py`: 传递历史问题到表选择逻辑
- `backend/apps/datasource/crud/datasource.py`: 在表嵌入时使用历史问题
- `backend/common/core/config.py`: 添加多轮上下文相关配置