### PR TITLE
fix(ai_model): support reasoning field for Ollama/LMStudio thinking models

### DIFF
--- a/backend/apps/ai_model/openai/llm.py
+++ b/backend/apps/ai_model/openai/llm.py
@@ -27,8 +27,12 @@ def _convert_delta_to_message_chunk(
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
-    if 'reasoning_content' in _dict:
-        additional_kwargs['reasoning_content'] = _dict.get('reasoning_content')
+    # 兼容 reasoning_content (DeepSeek等) 和 reasoning (Ollama/LMStudio GPT-OSS) 两种字段
+    reasoning_content = _dict.get('reasoning_content')
+    if not reasoning_content:
+        reasoning_content = _dict.get('reasoning')
+    if reasoning_content:
+        additional_kwargs['reasoning_content'] = reasoning_content
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:


### PR DESCRIPTION
## Summary
- 添加对 `reasoning` 字段的兼容支持（Ollama/LMStudio 遵循 GPT-OSS 官方建议）
- 保持与现有 `reasoning_content` 字段的向后兼容（DeepSeek 等）
- 优先级：`reasoning_content` > `reasoning`（回退）

## 问题描述
当连接 Ollama/LMStudio 托管的思考模型（如 GPT-OSS 120B）时，界面上的思考过程始终为空。

根因：Ollama/LMStudio 在返回 JSON 中使用 `reasoning` 字段，而代码只提取 `reasoning_content`。

## 测试方法
1. 使用 Ollama/LMStudio 连接支持思考的模型
2. 发送查询，确认思考过程正常显示
3. 测试 DeepSeek 等模型确保向后兼容