### PR TITLE
feat(config): 添加推荐问题功能开关配置

### DIFF
--- a/backend/apps/chat/api/chat.py
+++ b/backend/apps/chat/api/chat.py
@@ -21,6 +21,7 @@ from apps.chat.task.llm import LLMService
 from apps.swagger.i18n import PLACEHOLDER_PREFIX
 from apps.system.schemas.permission import SqlbotPermission, require_permissions
 from common.core.deps import CurrentAssistant, SessionDep, CurrentUser, Trans
+from common.core.config import settings
 from common.utils.command_utils import parse_quick_command
 from common.utils.data_format import DataFormat
 from common.audit.models.log_model import OperationType, OperationModules
@@ -197,6 +198,9 @@ async def ask_recommend_questions(session: SessionDep, current_user: CurrentUser
                                   current_assistant: CurrentAssistant, articles_number: Optional[int] = 4):
     def _return_empty():
         yield 'data:' + orjson.dumps({'content': '[]', 'type': 'recommended_question'}).decode() + '\n\n'
+
+    if not settings.RECOMMENDED_QUESTIONS_ENABLED:
+        return StreamingResponse(_return_empty(), media_type="text/event-stream")
 
     try:
         record = get_chat_record_by_id(session, chat_record_id)

--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -124,6 +124,9 @@ class Settings(BaseSettings):
     TABLE_EMBEDDING_COUNT: int = 10
     DS_EMBEDDING_COUNT: int = 10
 
+    # 推荐问题配置（LLM生成）
+    RECOMMENDED_QUESTIONS_ENABLED: bool = True
+
     ORACLE_CLIENT_PATH: str = '/opt/sqlbot/db_client/oracle_instant_client'
 
     @field_validator('SQL_DEBUG',
@@ -132,6 +135,7 @@ class Settings(BaseSettings):
                      'PARSE_REASONING_BLOCK_ENABLED',
                      'PG_POOL_PRE_PING',
                      'TABLE_EMBEDDING_ENABLED',
+                     'RECOMMENDED_QUESTIONS_ENABLED',
                      mode='before')
     @classmethod
     def lowercase_bool(cls, v: Any) -> Any:


### PR DESCRIPTION
## 概述
- 添加系统级配置 `RECOMMENDED_QUESTIONS_ENABLED`，用于启用/禁用 LLM 生成推荐问题功能
- 禁用时，API 直接返回空数组，不调用 LLM
- 影响范围：快捷提问的"推荐" tab 和发送消息后的建议提问

## 改动文件
- `backend/common/core/config.py`: 添加 `RECOMMENDED_QUESTIONS_ENABLED` 配置项（默认: true）
- `backend/apps/chat/api/chat.py`: 在 `ask_recommend_questions` 接口添加配置检查

## 使用方法
在 `.env` 文件中设置：
```env
RECOMMENDED_QUESTIONS_ENABLED=false
