### PR TITLE
fix(datasource): sort fieldList results with enabled fields first

### DIFF
--- a/backend/apps/datasource/crud/field.py
+++ b/backend/apps/datasource/crud/field.py
@@ -9,14 +9,15 @@ def delete_field_by_ds_id(session: SessionDep, id: int):
 
 
 def get_fields_by_table_id(session: SessionDep, id: int, field: FieldObj):
+    order = (CoreField.checked.desc(), CoreField.field_index.asc())
     if field and field.fieldName:
         return session.query(CoreField).filter(
             and_(CoreField.table_id == id, or_(CoreField.field_name.like(f'%{field.fieldName}%'),
                                                CoreField.field_name.like(f'%{field.fieldName.lower()}%'),
                                                CoreField.field_name.like(f'%{field.fieldName.upper()}%')))).order_by(
-            CoreField.field_index.asc()).all()
+            *order).all()
     else:
-        return session.query(CoreField).filter(CoreField.table_id == id).order_by(CoreField.field_index.asc()).all()
+        return session.query(CoreField).filter(CoreField.table_id == id).order_by(*order).all()
 
 
 def update_field(session: SessionDep, item: CoreField):


### PR DESCRIPTION
[#898](https://github.com/dataease/SQLBot/issues/898) 
Sort by checked DESC, then field_index ASC. 