### PR TITLE
fix: add missing comma in whitelist.py causing /mcp* routes to be unw…

### DIFF
--- a/backend/common/utils/whitelist.py
+++ b/backend/common/utils/whitelist.py
@@ -21,7 +21,7 @@ wlist = [
     "*.ttf",
     "*.eot",
     "*.otf",
-    "*.css.map"
+    "*.css.map",
     "/mcp*",
     "/system/license",
     "/system/config/key",


### PR DESCRIPTION
…hitelisted

"*.css.map" was missing a trailing comma, causing Python's implicit string literal concatenation to merge it with the next entry into "*.css.map/mcp*". This made the /mcp* whitelist rule never match, so all /mcp/* endpoints were blocked by TokenMiddleware with "Miss Token[X-SQLBOT-TOKEN]" even though they are intended to handle their own authentication internally.