### PR TITLE
fix(table relationship): In the table relationship editing interface,…

### DIFF
--- a/frontend/src/views/ds/TableRelationship.vue
+++ b/frontend/src/views/ds/TableRelationship.vue
@@ -509,8 +509,6 @@ const save = () => {
   touch-action: none;
   box-sizing: border-box;
   position: relative;
-  min-width: 400px;
-  min-height: 600px;
   width: 100%;
   height: 100%;
   background-color: #f5f6f7;


### PR DESCRIPTION
… when the browser zoom is adjusted to 150%, dragging in a table causes the surrounding elements to flicker. #1123