### PR TITLE
fix(terminology): prevent path traversal in Excel upload

### DIFF
--- a/backend/apps/terminology/api/terminology.py
+++ b/backend/apps/terminology/api/terminology.py
@@ -177,9 +177,15 @@ async def upload_excel(trans: Trans, current_user: CurrentUser, file: UploadFile
         raise HTTPException(400, "Only support .xlsx/.xls")
 
     os.makedirs(path, exist_ok=True)
-    base_filename = f"{file.filename.split('.')[0]}_{hashlib.sha256(uuid.uuid4().bytes).hexdigest()[:10]}"
-    filename = f"{base_filename}.{file.filename.split('.')[1]}"
-    save_path = os.path.join(path, filename)
+    # Strip any directory components from the client-supplied filename to
+    # prevent path traversal (CWE-22).
+    safe_name = os.path.basename(file.filename)
+    name_root, name_ext = os.path.splitext(safe_name)
+    base_filename = f"{name_root}_{hashlib.sha256(uuid.uuid4().bytes).hexdigest()[:10]}"
+    filename = f"{base_filename}{name_ext}"
+    save_path = os.path.realpath(os.path.join(path, filename))
+    if os.path.commonpath([save_path, os.path.realpath(path)]) != os.path.realpath(path):
+        raise HTTPException(400, "Invalid filename")
     with open(save_path, "wb") as f:
         f.write(await file.read())
 
@@ -262,7 +268,9 @@ async def upload_excel(trans: Trans, current_user: CurrentUser, file: UploadFile
 
             df = pd.DataFrame(md_data, columns=_fields_list)
             error_excel_filename = f"{base_filename}_error.xlsx"
-            save_error_path = os.path.join(path, error_excel_filename)
+            save_error_path = os.path.realpath(os.path.join(path, error_excel_filename))
+            if os.path.commonpath([save_error_path, os.path.realpath(path)]) != os.path.realpath(path):
+                raise Exception("Invalid filename")
             # 保存 DataFrame 到 Excel
             df.to_excel(save_error_path, index=False)
 


### PR DESCRIPTION
## Summary

The terminology Excel upload endpoint (`POST /terminology/uploadExcel`, handler `upload_excel` in `backend/apps/terminology/api/terminology.py`) writes an uploaded file to disk using the client-supplied `file.filename` without stripping directory components. An authenticated workspace admin can send a multipart upload whose filename contains `../` segments and cause the server to write attacker-controlled bytes outside the intended `EXCEL_PATH` directory — a path traversal / arbitrary file write (CWE-22).

## Vulnerable code (before)

```python
base_filename = f"{file.filename.split('.')[0]}_{hashlib.sha256(uuid.uuid4().bytes).hexdigest()[:10]}"
filename = f"{base_filename}.{file.filename.split('.')[1]}"
save_path = os.path.join(path, filename)
with open(save_path, "wb") as f:
    f.write(await file.read())
```

`file.filename` is fully controlled by the client. `split('.')[0]` does not remove path separators, so a filename such as `../../etc/cron.d/pwn.xlsx` produces a `save_path` like `<EXCEL_PATH>/../../etc/cron.d/pwn_<hash>.xlsx`, which `os.path.join` happily resolves outside `EXCEL_PATH`. The file body is then written verbatim.

## Fix

Two-layer defense applied to both the primary save and the error-report save further down the same handler:

1. `os.path.basename(file.filename)` strips any directory components from the client string before it is used to build the on-disk name.
2. After joining, `os.path.realpath` is compared against `os.path.realpath(path)` via `os.path.commonpath`. If the resolved destination escapes the base directory (e.g. via a symlink under `path`, or any other bypass we missed), the request is rejected with HTTP 400.

The extension is now derived with `os.path.splitext` instead of `split('.')[1]`, which also fixes a latent `IndexError` on filenames without a dot and preserves multi-dot names correctly.

Diff is 12 additions / 4 deletions in a single file.

## Proof of concept

Against a running SQLBot instance, authenticated as a workspace admin:

```bash
# Craft an xlsx with a traversal filename
printf 'PWNED' > /tmp/payload.xlsx
curl -X POST "https://<host>/terminology/uploadExcel?ws_id=1" \
  -H "Authorization: Bearer <ws_admin_token>" \
  -F 'file=@/tmp/payload.xlsx;filename=../../../../tmp/sqlbot_pwn.xlsx'
```

Before the patch: a file matching `/tmp/sqlbot_pwn_*.xlsx` appears on the host filesystem, outside the terminology excel directory. On real deployments the traversal target could be a writable location such as `/etc/cron.d/`, an application source file, or a static asset — turning workspace-admin into host-level arbitrary write, and in many environments into RCE.

After the patch: the basename strip reduces the filename to `sqlbot_pwn.xlsx` and the containment check rejects anything that still resolves outside `EXCEL_PATH`.

## Security analysis

- Entry point: `@router.post("/uploadExcel")` bound to `upload_excel`.
- Sink: `open(save_path, "wb").write(await file.read())` and the later `df.to_excel(save_error_path, ...)`.
- Source: `file.filename` from the `UploadFile` — attacker-controlled.
- Auth: the endpoint requires an authenticated workspace admin. Because SQLBot is a multi-tenant product (workspaces, roles), workspace-admin is a lower privilege than host filesystem access, so this is a meaningful privilege escalation, not an equivalence.

### Adversarial review

Before submitting we tried to disprove this. Candidates considered:

- *"Starlette or FastAPI already sanitizes `UploadFile.filename`."* It does not — `filename` is passed through from the multipart `Content-Disposition` header verbatim; this is documented and easy to reproduce locally.
- *"`os.path.join` will refuse traversal."* It won't — `os.path.join('/a/b', '../../etc/x')` returns `/a/b/../../etc/x` and `open()` follows it.
- *"ws_admin already has host access."* It doesn't in the shipped Docker image; ws_admin is a tenant role, not a system role.
- *"The `split('.')[0]` trims the traversal."* Only the extension side; the path prefix survives.

None of the mitigations hold, so the finding is exploitable as described.

## Testing

- Re-read the handler and confirmed both write sites (`save_path` and `save_error_path`) are covered by the basename + realpath/commonpath check.
- Verified locally that `os.path.basename('../../etc/cron.d/x.xlsx')` returns `x.xlsx`, and that `os.path.commonpath` yields a mismatching prefix for escapes, which the code treats as invalid.
- Confirmed `os.path.splitext` preserves the extension for normal cases (`foo.xlsx` → `.xlsx`) and no longer raises on filenames without a dot.
- Existing behavior for legitimate uploads is unchanged: the random hex suffix and directory layout are preserved.