### PR TITLE
fix(db): parameterize Kingbase get_tables/get_fields queries (CWE-89)

### DIFF
--- a/backend/apps/db/db.py
+++ b/backend/apps/db/db.py
@@ -527,7 +527,7 @@ def get_tables(ds: CoreDatasource):
                 return res_list
         elif equals_ignore_case(ds.type, 'kingbase'):
             with get_driver_connection(ds) as conn, conn.cursor() as cursor:
-                cursor.execute(sql.format(sql_param))
+                cursor.execute(sql, (sql_param,))
                 res = cursor.fetchall()
                 res_list = [TableSchema(*item) for item in res]
                 return res_list
@@ -577,7 +577,7 @@ def get_fields(ds: CoreDatasource, table_name: str = None):
                 return res_list
         elif equals_ignore_case(ds.type, 'kingbase'):
             with get_driver_pool(ds).connection() as conn, conn.cursor() as cursor:
-                cursor.execute(sql.format(p1, p2))
+                cursor.execute(sql, (p1, p2) if p2 is not None and p2 != "" else (p1,))
                 res = cursor.fetchall()
                 res_list = [ColumnSchema(*item) for item in res]
                 return res_list

--- a/backend/apps/db/db_sql.py
+++ b/backend/apps/db/db_sql.py
@@ -154,7 +154,7 @@ def get_table_sql(ds: CoreDatasource, conf: DatasourceConf, db_version: str = ''
                    pg_namespace n ON n.oid = c.relnamespace
                        LEFT JOIN
                    pg_description d ON d.objoid = c.oid AND d.objsubid = 0
-              WHERE n.nspname = '{0}'
+              WHERE n.nspname = %s
                 AND c.relkind IN ('r', 'v', 'p', 'm')
                 AND c.relname NOT LIKE 'pg_%'
                 AND c.relname NOT LIKE 'sql_%'
@@ -308,11 +308,11 @@ def get_field_sql(ds: CoreDatasource, conf: DatasourceConf, table_name: str = No
                             pg_catalog.pg_class c ON a.attrelid = c.oid
                                 JOIN
                             pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                       WHERE n.nspname = '{0}'
+                       WHERE n.nspname = %s
                          AND a.attnum > 0
                          AND NOT a.attisdropped \
                        """
-        sql2 = " AND c.relname = '{1}'" if table_name is not None and table_name != "" else ""
+        sql2 = " AND c.relname = %s" if table_name is not None and table_name != "" else ""
         return sql1 + sql2, conf.dbSchema, table_name
     elif equals_ignore_case(ds.type, "es"):
         return "", None, None


### PR DESCRIPTION
## Summary

SQL injection (CWE-89) in the Kingbase branches of `get_tables` and `get_fields` in `backend/apps/db/db.py`. The Kingbase code path built its query with Python `str.format(...)` and passed the fully-interpolated string to `cursor.execute(...)`, unlike the sibling branches for Redshift / StarRocks / Doris in the same function which already use proper `%s` parameter binding.

For `get_fields`, the interpolated value `p2` is the `table_name` path parameter from `POST /datasource/getFields/{id}/{table_name}` (see `backend/apps/datasource/api/datasource.py:157`), so it is directly attacker-controlled and flows unescaped into a SQL statement executed against the workspace's configured Kingbase datasource.

## Affected code

- `backend/apps/db/db.py::get_tables` — Kingbase branch, `cursor.execute(sql.format(sql_param))`
- `backend/apps/db/db.py::get_fields` — Kingbase branch, `cursor.execute(sql.format(p1, p2))` where `p2 == table_name`
- `backend/apps/db/db_sql.py::get_table_sql` / `get_field_sql` — the Kingbase templates used `'{0}'` / `'{1}'` string placeholders

## Fix

- Rewrite the Kingbase SQL templates in `db_sql.py` to use `%s` placeholders instead of `'{0}'` / `'{1}'`.
- In `db.py`, pass parameters as a tuple to `cursor.execute` (`cursor.execute(sql, (sql_param,))` and `cursor.execute(sql, (p1, p2))`). This matches the pattern already used for the other PostgreSQL-like backends in the same function.
- `get_fields` handles the optional-table_name case by only binding `(p1,)` when `sql2` is empty, so the placeholder count stays in sync with the SQL.

The Kingbase driver (ksycopg2 / psycopg2-compatible) supports `%s` parameter binding, so no behavioural change is expected — only the interpolation site changes.

## Security analysis

Data flow for the higher-severity path:

1. `POST /datasource/getFields/{id}/{table_name}` — `table_name` is a path parameter (no validation).
2. `getFields(...)` in `crud/datasource.py` forwards it to `db.get_fields(ds, table_name=...)`.
3. Pre-fix, on Kingbase, `table_name` reaches `sql.format(p1, p2)` and is embedded in a query executed against the datasource's Kingbase instance.

Preconditions:
- Workspace-admin (`ws_admin`) role in a workspace that has a Kingbase datasource configured.

Impact: SQL execution against the customer's Kingbase DB with the datasource's DB credentials. That is a strictly wider capability than the intended "list columns for this table" — cross-schema reads, and depending on driver behaviour, potentially stacked statements. `get_tables`' `sql_param` is derived from `conf.dbSchema` (admin-supplied at datasource creation), so the exposure there is lower but the same fix applies for consistency.

## Adversarial review

Before submitting we checked whether the workspace-admin gate makes this a non-issue. It does not: workspace admin is an application role, not equivalent to Kingbase DBA, and the datasource credentials are typically distinct from — and potentially more privileged than — what a ws_admin should be able to run arbitrary SQL as. We also confirmed the same function's Redshift / StarRocks / Doris branches already use parameter binding, so this is an inconsistency rather than an intentional design.

## Proof of concept

Verified route: `backend/apps/datasource/api/datasource.py:157` mounts `POST /datasource/getFields/{id}/{table_name}` which calls `getFields(...)` -> `db.get_fields(ds, table_name)`.

With a workspace-admin session cookie and `{id}` pointing at a Kingbase datasource:

```
POST /datasource/getFields/<kingbase_ds_id>/foo'%20AND%201%3D(SELECT%20version())--%20 HTTP/1.1
Host: <sqlbot>
Cookie: <ws_admin session>
```

Pre-fix, the `table_name` segment is interpolated into the Kingbase query verbatim via `.format(...)` and the injected fragment is parsed as SQL by the backend. Post-fix, the same value is bound as a parameter and treated as a literal string comparison against `c.relname`, returning an empty result set instead of executing the injected SQL.

## Testing

- Manual review of `git diff` on the two files — the parameter tuples match the number of `%s` placeholders in every branch (`(sql_param,)`, `(p1, p2)`, and `(p1,)` when the optional `sql2` clause is omitted).
- Cross-checked against the sibling Redshift / StarRocks / Doris branches in the same function to confirm the fix uses the exact same shape they already use.
- Grepped the repo for other `sql.format(` call sites reaching `cursor.execute` on Kingbase — none remain.