### PR TITLE
Use v-dompurify-html in SQText to prevent XSS

### DIFF
--- a/frontend/src/views/dashboard/components/sq-text/index.vue
+++ b/frontend/src/views/dashboard/components/sq-text/index.vue
@@ -16,7 +16,7 @@
       @keyup.stop
       @mousedown.stop
       @dblclick.stop="setEdit"
-      v-html="configItem.propValue"
+      v-dompurify-html="configItem.propValue"
     ></div>
     <editor
       :id="tinymceId"


### PR DESCRIPTION
The SQText dashboard component rendered TinyMCE output with v-html, bypassing the DOMPurify sanitization used by every other component. Replace with v-dompurify-html (already registered globally in main.ts).
fix #1308 