### PR TITLE
fix: handle extra Hive DESCRIBE columns

### DIFF
--- a/backend/apps/datasource/models/datasource.py
+++ b/backend/apps/datasource/models/datasource.py
@@ -159,7 +159,7 @@ class TableSchemaResponse(BaseModel):
 
 
 class ColumnSchema:
-    def __init__(self, attr1, attr2, attr3):
+    def __init__(self, attr1, attr2, attr3, *_extra_columns):
         self.fieldName = attr1
         self.fieldType = attr2
         self.fieldComment = attr3 if attr3 is None or isinstance(attr3, str) else attr3.decode("utf-8")

--- a/tests/test_hive_column_schema.py
+++ b/tests/test_hive_column_schema.py
@@ -1,0 +1,32 @@
+"""Regression tests for Hive DESCRIBE result handling."""
+
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+class HiveColumnSchemaTestCase(unittest.TestCase):
+    def test_ignores_driver_specific_describe_metadata(self) -> None:
+        from apps.datasource.models.datasource import ColumnSchema
+
+        row = (
+            "customer_id",
+            "bigint",
+            "customer identifier",
+            "PRIMARY_KEY",
+            "",
+            "",
+        )
+
+        field = ColumnSchema(*row)
+
+        self.assertEqual("customer_id", field.fieldName)
+        self.assertEqual("bigint", field.fieldType)
+        self.assertEqual("customer identifier", field.fieldComment)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1210.

ArgoDB's Hive driver appends metadata to `DESCRIBE` rows. `ColumnSchema` now keeps the standard name, type, and comment fields while ignoring trailing driver-specific values. A regression test covers the reported arity failure.

Tests:
- `python tests/test_hive_column_schema.py`
- `pytest tests/test_hive_column_schema.py tests/test_supplier_config.py tests/test_minimax_integration.py tests/test_cwe89_escape_fix.py -q` (54 passed, 3 skipped)
- `ruff check tests/test_hive_column_schema.py`