### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ docker run -d \
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dataease/sqlbot&type=Date)](https://www.star-history.com/#dataease/sqlbot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dataease/sqlbot&type=Date)](https://star-history.dera.page/#dataease/sqlbot&Date)
 
 ## 飞致云旗下的其他明星项目
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -90,7 +90,7 @@ If you are in an intranet environment, you can deploy SQLBot via the [offline in
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dataease/sqlbot&type=Date)](https://www.star-history.com/#dataease/sqlbot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dataease/sqlbot&type=Date)](https://star-history.dera.page/#dataease/sqlbot&Date)
 
 ## Other star projects under FIT2CLOUD
 


### PR DESCRIPTION
The star history chart in the README (and the English translation) is currently broken because the old service relies on the GitHub stargazer API, which is now restricted.

This change updates the chart to use the new star history domain, so the chart renders correctly again.

Both the main README and the English README in docs/ are updated.